### PR TITLE
Make PHP version selectable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Restarting php7.1-fpm on Cloudways servers from a [Deployer](https://deployer,org) file.
+# Restarting php-fpm on Cloudways servers from a [Deployer](https://deployer,org) file.
 
-A quick and dirty deployer task to restart php7.1 fpm hosted on cloudways
+A quick and dirty deployer task to restart php-fpm hosted on cloudways
 
 Should be simple to modify to restart other services. See https://platform.cloudways.com/api
 
@@ -10,13 +10,13 @@ You need a [Cloudways](https://www.cloudways.com) account and server, an api key
 
 ## Installation
 
-It's just a couple of utility functions and a deployer task. Either download and include [restart-php7.1-fpm.php](restart-php7.1-fpm.php) or install via composer:
+It's just a couple of utility functions and a deployer task. Either download and include [restart-php-fpm.php](restart-php-fpm.php) or install via composer:
 
 `composer require --dev samyapp/cloudways-restart-php-deployer-task`
 
 ## Usage
 
-In your `deploy.php` script, include [restart-php7.1-fpm.php](restart-php7.1-fpm.php) after you include your recipes.
+In your `deploy.php` script, include [restart-php-fpm.php](restart-php-fpm.php) after you include your recipes.
 
 Then set the following variables:
 
@@ -27,6 +27,9 @@ set('cloudways_email', 'you@cloudways-account-email.com');
 // the id of the cloudways server to restart
 set('cloudways_server_id', 42); 
 
+// the php version to restart
+set('cloudways_php_version', '8.1');
+
 // your cloudways api key - you could hard code this in your deploy script of
 // just set it in your environment instead.
 set('cloudways_api_key', $_ENV['CLOUDWAYS_API_KEY']);
@@ -34,5 +37,5 @@ set('cloudways_api_key', $_ENV['CLOUDWAYS_API_KEY']);
 Finally, call the restart task from somewhere appropriate, eg:
 
 ```php
-after('deploy:symlink', 'deploy:restart-php7.1-fpm');
+after('deploy:symlink', 'deploy:restart-php-fpm');
 ```

--- a/restart-php-fpm.php
+++ b/restart-php-fpm.php
@@ -14,7 +14,7 @@ function cloudways_oauth($email, $api_key)
 {
 	$url = 'https://api.cloudways.com/api/v1/oauth/access_token';
 	$data = [
-		'email' => $email, get('cloudways_email'),
+		'email' => $email,
 		'api_key' => $api_key,
 	];
 

--- a/restart-php-fpm.php
+++ b/restart-php-fpm.php
@@ -45,7 +45,7 @@ function cloudways_restartphp($server, $token) {
 	$url = 'https://api.cloudways.com/api/v1/service/state';
 	$data = [
 		'server_id' => $server,
-		'service' => 'php7.1-fpm',
+        'service' => 'php' . get('cloudways_php_version') . '-fpm',
 		'state' => 'restart',
 	];
 
@@ -66,8 +66,8 @@ function cloudways_restartphp($server, $token) {
 	return false;
 }
 
-desc('Restart php 7.1 fpm on cloudways server');
-task('deploy:restart-php7.1-fpm', function() {
+desc('Restart php ' . get('cloudways_php_version') . ' fpm on cloudways server');
+task('deploy:restart-php-fpm', function() {
 	$token = cloudways_oauth(get('cloudways_email'), get('cloudways_api_key'));
 	if($token) {
 		if(!cloudways_restartphp(get('cloudways_server_id'), $token)) {
@@ -89,6 +89,6 @@ set('cloudways_server_id', 42); // the id of the cloudways server to restart
 // your cloudways api key - you could hard code this in your deploy script of
 // just set it in your environment instead.
 set('cloudways_api_key', $_ENV['CLOUDWAYS_API_KEY']);
-after('deploy:symlink', 'deploy:restart-php7.1-fpm');
+after('deploy:symlink', 'deploy:restart-php-fpm');
 
 */


### PR DESCRIPTION
Not sure if this repository's still alive, but I'll give it a go :-)

I needed to restart Cloudways PHP-FPM service during deploy with `Deployer`. Found this package, but only had PHP 7.1 support. Made some minor adjustments so the PHP-version can be selected.

Tested it and seams to be working fine :)

Thanks for a great package!